### PR TITLE
Fixed a few tests

### DIFF
--- a/articles/tests.py
+++ b/articles/tests.py
@@ -241,7 +241,7 @@ class ArticleAdminTestCase(TestCase, ArticleUtilMixin):
 
         # mark some articles active
         self.client.post(reverse('admin:articles_article_changelist'), {
-            '_selected_action': ['1','2','3'],
+            '_selected_action': Article.objects.all().values_list('id', flat=True)[0:3],
             'index': 0,
             'action': 'mark_active',
         })
@@ -260,7 +260,7 @@ class ArticleAdminTestCase(TestCase, ArticleUtilMixin):
 
         # mark some articles inactive
         self.client.post(reverse('admin:articles_article_changelist'), {
-            '_selected_action': ['1','2','3'],
+            '_selected_action': Article.objects.all().values_list('id', flat=True)[0:3],
             'index': 0,
             'action': 'mark_inactive',
         })
@@ -282,7 +282,7 @@ class ArticleAdminTestCase(TestCase, ArticleUtilMixin):
 
         # mark them with the other status
         self.client.post(reverse('admin:articles_article_changelist'), {
-            '_selected_action': ['1','2'],
+            '_selected_action': Article.objects.all().values_list('id', flat=True),
             'index': 0,
             'action': 'mark_status_%s' % (other_status.id,),
         })
@@ -352,25 +352,25 @@ class FeedTestCase(TestCase, ArticleUtilMixin):
     def test_latest_entries(self):
         """Makes sure the latest entries feed works"""
 
-        res = self.client.get(reverse('articles_feed', args=['latest']))
+        res = self.client.get(reverse('articles_rss_feed_latest'))
         self.assertEqual(res.status_code, 200)
 
-        res = self.client.get(reverse('articles_feed_atom', args=['latest']))
+        res = self.client.get(reverse('articles_atom_feed_latest'))
         self.assertEqual(res.status_code, 200)
 
     def test_tags(self):
         """Makes sure that the tags feed works"""
 
-        res = self.client.get(reverse('articles_feed', args=['tags/demo']))
+        res = self.client.get(reverse('articles_rss_feed_tag', args=['demo']))
         self.assertEqual(res.status_code, 200)
 
-        res = self.client.get(reverse('articles_feed', args=['tags/demo/']))
+        res = self.client.get(reverse('articles_rss_feed_tag', args=['demox']))
         self.assertEqual(res.status_code, 404)
 
-        res = self.client.get(reverse('articles_feed_atom', args=['tags/demo']))
+        res = self.client.get(reverse('articles_atom_feed_tag', args=['demo']))
         self.assertEqual(res.status_code, 200)
 
-        res = self.client.get(reverse('articles_feed_atom', args=['tags/demo/']))
+        res = self.client.get(reverse('articles_atom_feed_tag', args=['demox']))
         self.assertEqual(res.status_code, 404)
 
 class FormTestCase(TestCase, ArticleUtilMixin):


### PR DESCRIPTION
A few tests were failing for me on my setup (OSX 10.7, Python 2.7, MySQL 5.5):
- FeedTestCase would fail because the view names changed in a recent update
- ArticleAdminTestCase would fail if the auto-increment wasn't being reset between tests (For me it wasn't), the first test would create article ids [1,2,3,4,5], and the next test would get [6,7,8,9,10], which would be out of sync with the _select_action values.
