### PR TITLE
Close html tags when generating article description

### DIFF
--- a/articles/models.py
+++ b/articles/models.py
@@ -14,6 +14,7 @@ from django.core.cache import cache
 from django.conf import settings
 from django.template.defaultfilters import slugify, striptags
 from django.utils.translation import ugettext_lazy as _
+from django.utils.text import truncate_html_words
 
 from decorators import logtime, once_per_instance
 
@@ -456,14 +457,9 @@ class Article(models.Model):
         """
         if not self._teaser:
             if len(self.description.strip()):
-                text = self.description
+                self._teaser = self.description
             else:
-                text = self.rendered_content
-
-            words = text.split(' ')
-            if len(words) > WORD_LIMIT:
-                text = '%s...' % ' '.join(words[:WORD_LIMIT])
-            self._teaser = text
+                self._teaser = truncate_html_words(self.rendered_content, WORD_LIMIT)
 
         return self._teaser
     teaser = property(_get_teaser)


### PR DESCRIPTION
Hi,

First I'd like to thank you for great blog application. I started using it like two years ago and never looked back.

Now to my commit, I noticed that upon creation, articles' description is generated from rendered content, only truncated. Truncated html text had no closing tag, so I used Django's utility function, which closes html tags after truncation.

Best regards,
kwalo
