### PR TITLE
replace attachment.path with uploadedfile.url

### DIFF
--- a/articles/models.py
+++ b/articles/models.py
@@ -513,7 +513,7 @@ class Attachment(models.Model):
 
     @property
     def content_type_class(self):
-        mt = mimetypes.guess_type(self.attachment.path)[0]
+        mt = mimetypes.guess_type(self.uploadedfile.url)[0]
         if mt:
             content_type = mt.replace('/', '_')
         else:


### PR DESCRIPTION
This change replaces attachment.path with uploadedfile.url for
compatibility with django-storage.

Testing done (django 1.4):
- Before the change, I was getting a NotImplementedError exception of
  "This backend doesn't support absolute paths."
- After the change, I'm able to upload attachments to AWS as well as a
  local file system.
